### PR TITLE
Added <= <, >, >= but not == to XMoney.  Operations convert to the same

### DIFF
--- a/money/money.py
+++ b/money/money.py
@@ -336,9 +336,22 @@ class XMoney(Money):
             other = other.to(self._currency)
         return super(XMoney, self).__divmod__(other)
 
+    def __lt__(self, other):
+        if isinstance(other, Money):
+            other = other.to(self._currency)
+        return super(XMoney, self).__lt__(other)
+    
+    def __le__(self, other):
+        if isinstance(other, Money):
+            other = other.to(self._currency)
+        return super(XMoney, self).__le__(other)
+    
+    def __ge__(self, other):
+        if isinstance(other, Money):
+            other = other.to(self._currency)
+        return super(XMoney, self).__ge__(other)
 
-
-
-
-
-
+    def __gt__(self, other):
+        if isinstance(other, Money):
+            other = other.to(self._currency)
+        return super(XMoney, self).__gt__(other)

--- a/money/tests/mixins.py
+++ b/money/tests/mixins.py
@@ -169,10 +169,6 @@ class NumericOperationsMixin(object):
         with self.assertRaises(InvalidOperandType):
             self.MoneyClass(0, 'XXX') < Decimal('0')
     
-    def test_lt_money_different_currency(self):
-        with self.assertRaises(CurrencyMismatch):
-            self.MoneyClass(2, 'AAA') < self.MoneyClass(2, 'BBB')
-    
     def test_le(self):
         self.assertTrue(self.MoneyClass('2.219', 'XXX') <= self.MoneyClass('2.99', 'XXX'))
         self.assertTrue(self.MoneyClass('-2.99', 'XXX') <= self.MoneyClass('2.99', 'XXX'))
@@ -182,11 +178,7 @@ class NumericOperationsMixin(object):
     def test_le_works_only_with_money(self):
         with self.assertRaises(InvalidOperandType):
             self.MoneyClass(0, 'XXX') <= Decimal('0')
-    
-    def test_le_money_different_currency(self):
-        with self.assertRaises(CurrencyMismatch):
-            self.MoneyClass(2, 'AAA') <= self.MoneyClass(2, 'BBB')
-    
+        
     def test_eq(self):
         self.assertEqual(self.MoneyClass('2', 'XXX'), self.MoneyClass('2', 'XXX'))
         self.assertEqual(hash(self.MoneyClass('2', 'XXX')), hash(self.MoneyClass('2', 'XXX')))
@@ -215,11 +207,7 @@ class NumericOperationsMixin(object):
     def test_gt_works_only_with_money(self):
         with self.assertRaises(InvalidOperandType):
             self.MoneyClass(0, 'XXX') > Decimal('0')
-    
-    def test_gt_money_different_currency(self):
-        with self.assertRaises(CurrencyMismatch):
-            self.MoneyClass(2, 'AAA') > self.MoneyClass(2, 'BBB')
-    
+        
     def test_ge(self):
         self.assertTrue(self.MoneyClass('2.99', 'XXX') >= self.MoneyClass('2.219', 'XXX'))
         self.assertTrue(self.MoneyClass('2.99', 'XXX') >= self.MoneyClass('-2.99', 'XXX'))
@@ -228,10 +216,6 @@ class NumericOperationsMixin(object):
     def test_ge_works_only_with_money(self):
         with self.assertRaises(InvalidOperandType):
             self.MoneyClass(0, 'XXX') >= Decimal('0')
-    
-    def test_ge_money_different_currency(self):
-        with self.assertRaises(CurrencyMismatch):
-            self.MoneyClass(2, 'AAA') >= self.MoneyClass(2, 'BBB')
     
     def test_bool_true(self):
         self.assertTrue(self.MoneyClass('2.99', 'XXX'))

--- a/money/tests/test_money.py
+++ b/money/tests/test_money.py
@@ -6,6 +6,7 @@ import unittest
 
 from money import Money
 from . import mixins
+from money.exceptions import CurrencyMismatch
 
 
 class TestMoneyInstantiation(mixins.InstantiationMixin, unittest.TestCase):
@@ -36,7 +37,23 @@ class TestMoneyParser(mixins.ParserMixin, unittest.TestCase):
 class TestMoneyNumericOperations(mixins.NumericOperationsMixin, unittest.TestCase):
     def setUp(self):
         self.MoneyClass = Money
+        
+    def test_lt_money_different_currency(self):
+        with self.assertRaises(CurrencyMismatch):
+            self.MoneyClass(2, 'AAA') < self.MoneyClass(2, 'BBB')
+    
+    def test_le_money_different_currency(self):
+        with self.assertRaises(CurrencyMismatch):
+            self.MoneyClass(2, 'AAA') <= self.MoneyClass(2, 'BBB')
 
+    def test_gt_money_different_currency(self):
+        with self.assertRaises(CurrencyMismatch):
+            self.MoneyClass(2, 'AAA') > self.MoneyClass(2, 'BBB')
+            
+    def test_ge_money_different_currency(self):
+        with self.assertRaises(CurrencyMismatch):
+            self.MoneyClass(2, 'AAA') >= self.MoneyClass(2, 'BBB')
+    
 
 class TestMoneyUnaryOperationsReturnNew(mixins.UnaryOperationsReturnNewMixin, unittest.TestCase):
     def setUp(self):

--- a/money/tests/test_xmoney.py
+++ b/money/tests/test_xmoney.py
@@ -79,6 +79,21 @@ class TestXMoneyNumericOperations(mixins.NumericOperationsMixin, unittest.TestCa
         self.assertEqual(whole, Decimal('0'))
         self.assertEqual(remainder, Decimal('10'))
 
+    def test_gte_different_currency(self):
+        assert self.a >= self.b
+        
+    def test_gt_different_currency(self):
+        assert self.a > self.b
+
+    def test_lt_different_currency(self):
+        assert self.b < self.a
+        
+    def test_lte_different_currency(self):
+        assert self.b <= self.a
+        
+    def test_ne_different_currency(self):
+        assert self.a != self.b
+        
 
 class TestXMoneyUnaryOperationsReturnNew(mixins.UnaryOperationsReturnNewMixin, unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
currency as the left operand.  == is not defined because that would
either make the class unhashable, or make hashing an expensive operation.